### PR TITLE
feat: taken toevoegen via invoerveld

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,63 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-const tasks = [
+const initialTasks = [
   { id: 1, title: 'Presentatie maken over agent teams', status: 'in progress' },
   { id: 2, title: 'Demo repo opzetten op GitHub', status: 'done' },
   { id: 3, title: 'Live demo voorbereiden', status: 'open' },
 ];
 
 export default function App() {
+  const [tasks, setTasks] = useState(initialTasks);
+  const [newTitle, setNewTitle] = useState('');
+
+  const handleAdd = () => {
+    if (!newTitle.trim()) return;
+    setTasks([...tasks, {
+      id: Date.now(),
+      title: newTitle.trim(),
+      status: 'open',
+    }]);
+    setNewTitle('');
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') handleAdd();
+  };
+
   return (
     <div style={{ maxWidth: 600, margin: '2rem auto', fontFamily: 'sans-serif' }}>
       <h1>Taken</h1>
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+        <input
+          type="text"
+          value={newTitle}
+          onChange={e => setNewTitle(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Nieuwe taak..."
+          style={{
+            flex: 1,
+            padding: '0.5rem',
+            fontSize: '1rem',
+            border: '1px solid #ccc',
+            borderRadius: 4,
+          }}
+        />
+        <button
+          onClick={handleAdd}
+          disabled={!newTitle.trim()}
+          style={{
+            padding: '0.5rem 1rem',
+            fontSize: '1rem',
+            background: newTitle.trim() ? '#4CAF50' : '#ccc',
+            color: 'white',
+            border: 'none',
+            borderRadius: 4,
+            cursor: newTitle.trim() ? 'pointer' : 'not-allowed',
+          }}
+        >
+          Toevoegen
+        </button>
+      </div>
       <ul style={{ listStyle: 'none', padding: 0 }}>
         {tasks.map(task => (
           <li key={task.id} style={{


### PR DESCRIPTION
## Summary
- Voegt een tekstinvoerveld en "Toevoegen"-knop toe boven de takenlijst
- Nieuwe taken krijgen standaard de status `open`
- Invoerveld wordt leeggemaakt na toevoegen
- Lege titels worden geblokkeerd (knop is disabled)
- Enter-toets ondersteund voor snel toevoegen

Closes #1

## Test plan
- [ ] Voer een titel in en klik op "Toevoegen" — taak verschijnt in de lijst met status "open"
- [ ] Controleer dat het invoerveld leeg is na toevoegen
- [ ] Controleer dat de knop disabled is bij een leeg invoerveld
- [ ] Druk op Enter met een ingevulde titel — taak wordt toegevoegd

🤖 Generated with [Claude Code](https://claude.com/claude-code)