### PR TITLE
Taken toevoegen via invoerveld

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,66 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-const tasks = [
+const initialTasks = [
   { id: 1, title: 'Presentatie maken over agent teams', status: 'in progress' },
   { id: 2, title: 'Demo repo opzetten op GitHub', status: 'done' },
   { id: 3, title: 'Live demo voorbereiden', status: 'open' },
 ];
 
 export default function App() {
+  const [tasks, setTasks] = useState(initialTasks);
+  const [newTitle, setNewTitle] = useState('');
+
+  const handleAdd = () => {
+    if (!newTitle.trim()) return;
+    const newTask = {
+      id: Date.now(),
+      title: newTitle.trim(),
+      status: 'open',
+    };
+    setTasks([...tasks, newTask]);
+    setNewTitle('');
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && newTitle.trim()) {
+      handleAdd();
+    }
+  };
+
   return (
     <div style={{ maxWidth: 600, margin: '2rem auto', fontFamily: 'sans-serif' }}>
       <h1>Taken</h1>
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+        <input
+          type="text"
+          value={newTitle}
+          onChange={(e) => setNewTitle(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Nieuwe taak..."
+          style={{
+            flex: 1,
+            padding: '0.5rem',
+            fontSize: '1rem',
+            borderRadius: 4,
+            border: '1px solid #ccc',
+          }}
+        />
+        <button
+          onClick={handleAdd}
+          disabled={!newTitle.trim()}
+          style={{
+            padding: '0.5rem 1rem',
+            fontSize: '1rem',
+            borderRadius: 4,
+            border: 'none',
+            background: newTitle.trim() ? '#007bff' : '#ccc',
+            color: 'white',
+            cursor: newTitle.trim() ? 'pointer' : 'not-allowed',
+          }}
+        >
+          Toevoegen
+        </button>
+      </div>
       <ul style={{ listStyle: 'none', padding: 0 }}>
         {tasks.map(task => (
           <li key={task.id} style={{


### PR DESCRIPTION
Closes #1

## Wijzigingen
- Invoerveld en "Toevoegen"-knop toegevoegd boven de takenlijst
- Taken worden opgeslagen in React state (useState) in plaats van een vaste array
- Nieuwe taken krijgen standaard status `open`
- Invoerveld wordt leeggemaakt na toevoegen
- Knop is disabled bij lege invoer (visuele feedback + niet klikbaar)
- Enter-toets ondersteund voor sneller toevoegen

## Testplan
- Open de app en controleer dat het invoerveld en de knop zichtbaar zijn
- Typ een titel en klik op "Toevoegen" — taak verschijnt in de lijst met status `open`
- Controleer dat het invoerveld leeg is na toevoegen
- Controleer dat de knop disabled is bij een leeg invoerveld
- Test dat Enter ook werkt om een taak toe te voegen