### PR TITLE
Taken toevoegen via invoerveld

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-scripts": "5.0.1"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.59.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2927,6 +2930,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -11924,6 +11943,53 @@
         "node": ">=4"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -15426,23 +15492,6 @@
         }
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
@@ -15828,6 +15877,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15932,9 +15982,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -15942,7 +15992,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -16323,6 +16373,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,19 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  timeout: 30000,
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+  webServer: {
+    command: 'PORT=3000 npx react-scripts start',
+    port: 3000,
+    timeout: 30000,
+    reuseExistingServer: true,
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+});

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,59 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-const tasks = [
+const initialTasks = [
   { id: 1, title: 'Presentatie maken over agent teams', status: 'in progress' },
   { id: 2, title: 'Demo repo opzetten op GitHub', status: 'done' },
   { id: 3, title: 'Live demo voorbereiden', status: 'open' },
 ];
 
 export default function App() {
+  const [tasks, setTasks] = useState(initialTasks);
+  const [newTitle, setNewTitle] = useState('');
+
+  const handleAdd = () => {
+    if (!newTitle.trim()) return;
+    setTasks([...tasks, {
+      id: Date.now(),
+      title: newTitle.trim(),
+      status: 'open',
+    }]);
+    setNewTitle('');
+  };
+
   return (
     <div style={{ maxWidth: 600, margin: '2rem auto', fontFamily: 'sans-serif' }}>
       <h1>Taken</h1>
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+        <input
+          type="text"
+          value={newTitle}
+          onChange={e => setNewTitle(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && handleAdd()}
+          placeholder="Nieuwe taak..."
+          style={{
+            flex: 1,
+            padding: '0.5rem',
+            fontSize: '1rem',
+            border: '1px solid #ccc',
+            borderRadius: 4,
+          }}
+        />
+        <button
+          onClick={handleAdd}
+          disabled={!newTitle.trim()}
+          style={{
+            padding: '0.5rem 1rem',
+            fontSize: '1rem',
+            background: newTitle.trim() ? '#4CAF50' : '#ccc',
+            color: 'white',
+            border: 'none',
+            borderRadius: 4,
+            cursor: newTitle.trim() ? 'pointer' : 'not-allowed',
+          }}
+        >
+          Toevoegen
+        </button>
+      </div>
       <ul style={{ listStyle: 'none', padding: 0 }}>
         {tasks.map(task => (
           <li key={task.id} style={{

--- a/tests/taken-toevoegen.spec.js
+++ b/tests/taken-toevoegen.spec.js
@@ -1,0 +1,80 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Taken toevoegen via invoerveld (#1)', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('invoerveld en toevoegen-knop zijn zichtbaar', async ({ page }) => {
+    await expect(page.getByPlaceholder('Nieuwe taak...')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Toevoegen' })).toBeVisible();
+  });
+
+  test('nieuwe taak wordt toegevoegd met status open', async ({ page }) => {
+    const input = page.getByPlaceholder('Nieuwe taak...');
+    const button = page.getByRole('button', { name: 'Toevoegen' });
+
+    await input.fill('Mijn test taak');
+    await button.click();
+
+    const items = page.locator('li');
+    const lastItem = items.last();
+    await expect(lastItem).toContainText('Mijn test taak');
+    await expect(lastItem).toContainText('open');
+  });
+
+  test('invoerveld wordt leeggemaakt na toevoegen', async ({ page }) => {
+    const input = page.getByPlaceholder('Nieuwe taak...');
+    const button = page.getByRole('button', { name: 'Toevoegen' });
+
+    await input.fill('Tijdelijke taak');
+    await button.click();
+
+    await expect(input).toHaveValue('');
+  });
+
+  test('knop is disabled bij lege titel', async ({ page }) => {
+    const button = page.getByRole('button', { name: 'Toevoegen' });
+    const input = page.getByPlaceholder('Nieuwe taak...');
+
+    // Initieel leeg — knop moet disabled zijn
+    await expect(button).toBeDisabled();
+
+    // Na invullen — knop moet enabled zijn
+    await input.fill('Iets');
+    await expect(button).toBeEnabled();
+
+    // Na leegmaken — knop weer disabled
+    await input.fill('');
+    await expect(button).toBeDisabled();
+  });
+
+  test('lege titel kan niet worden toegevoegd', async ({ page }) => {
+    const initialCount = await page.locator('li').count();
+
+    // Probeer spaties toe te voegen via Enter
+    const input = page.getByPlaceholder('Nieuwe taak...');
+    await input.fill('   ');
+    await input.press('Enter');
+
+    // Aantal taken mag niet gewijzigd zijn
+    await expect(page.locator('li')).toHaveCount(initialCount);
+  });
+
+  test('Enter-toets voegt taak toe', async ({ page }) => {
+    const input = page.getByPlaceholder('Nieuwe taak...');
+
+    await input.fill('Enter taak');
+    await input.press('Enter');
+
+    const items = page.locator('li');
+    const lastItem = items.last();
+    await expect(lastItem).toContainText('Enter taak');
+    await expect(lastItem).toContainText('open');
+
+    // Invoerveld moet ook leeg zijn na Enter
+    await expect(input).toHaveValue('');
+  });
+
+});


### PR DESCRIPTION
Closes #1

## Wijzigingen
- Takenlijst omgezet van statische array naar React state (`useState`)
- Tekstinvoerveld en "Toevoegen"-knop toegevoegd boven de takenlijst
- Nieuwe taken krijgen standaard status `open`
- Invoerveld wordt leeggemaakt na toevoegen
- Knop is disabled bij lege titel (validatie)
- Enter-toets ondersteund als sneltoets

## Testplan
- Open de app in de browser
- Controleer dat het invoerveld en de knop zichtbaar zijn
- Typ een titel en klik "Toevoegen" — taak verschijnt met status `open`
- Controleer dat het invoerveld leeg is na toevoegen
- Controleer dat de knop disabled is bij een leeg invoerveld
- Test de Enter-toets als alternatief voor de knop